### PR TITLE
Fix "The payload is invalid" on null values

### DIFF
--- a/src/Casts/AESEncrypted.php
+++ b/src/Casts/AESEncrypted.php
@@ -18,6 +18,10 @@ class AESEncrypted implements CastsAttributes
      */
     public function get($model, $key, $value, $attributes)
     {
+        if (is_null($value)) {
+            return $value;
+        }
+        
         return EloquentAES::decrypt($value);
     }
 
@@ -32,6 +36,10 @@ class AESEncrypted implements CastsAttributes
      */
     public function set($model, $key, $value, $attributes)
     {
+        if (is_null($value)) {
+            return $value;
+        }
+        
         return EloquentAES::encrypt($value);
     }
 }

--- a/tests/Unit/EncryptedCastTest.php
+++ b/tests/Unit/EncryptedCastTest.php
@@ -44,4 +44,22 @@ class EncryptedCastTest extends TestCase
 
         $this->assertEquals('001100110011', $cast->set($user, 'encrypted', 'test', []));
     }
+
+    /** @test */
+    function decrypting_null_returns_null()
+    {
+        $cast = new AESEncrypted();
+        $user = new User();
+
+        $this->assertNull($cast->get($user, 'encrypted',null, []));
+    }
+
+    /** @test */
+    function encrypting_null_returns_null()
+    {
+        $cast = new AESEncrypted();
+        $user = new User();
+
+        $this->assertNull($cast->set($user, 'encrypted',null, []));
+    }
 }


### PR DESCRIPTION
When the attribute to be chastised is null, the error "The payload is invalid" is raised. With this commit I correct this problem.