### PR TITLE
require illuminate/support 8 to enforce Laravel 8+ requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "A Laravel Eloquent package to allow for model attribute encryption, using a seperate key",
     "type": "library",
     "require": {
-        "php": "^7.3"
+        "php": "^7.3",
+        "illuminate/support": "^8.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
I missed the line in the documentation indicating this package required Laravel 8, and installed this in a Laravel 6 project.

This PR should prevent that from happening by enforcing the requirement during installation.

Thanks!